### PR TITLE
fix: TS .d.ts resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,23 @@
   "license": "MIT",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./dist/index.js"
     },
     "./merge": {
-      "import": "./merge/index.mjs",
-      "require": "./merge/index.js"
+      "import": {
+        "types": "./merge/index.d.ts",
+        "default": "./merge/index.mjs"
+      },  
+      "require": {
+        "types": "./merge/index.d.ts",
+        "default": "./merge/index.js"
+      }
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
There are types at '/node_modules/dset/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'dset' library may need to update its package.json or typings.ts(7016)